### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5.3.0
+        uses: actions/setup-go@v5.4.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.2.1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v5.4.0](https://github.com/actions/setup-go/releases/tag/v5.4.0)** on 2025-03-19T02:38:36Z
