### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.4.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.2.1
+        uses: goreleaser/goreleaser-action@v6.3.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action)** published a new release **[v6.3.0](https://github.com/goreleaser/goreleaser-action/releases/tag/v6.3.0)** on 2025-03-30T11:10:15Z
